### PR TITLE
feat(analyzer): add way to identify assertion roulettes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target/
 !.mvn/wrapper/maven-wrapper.jar
+.env
 
 ### STS ###
 .apt_generated

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,11 @@
             <version>1.0.2</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.github.cdimascio</groupId>
+            <artifactId>java-dotenv</artifactId>
+            <version>5.2.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/br/edu/ifc/blumenau/analyzer/Main.java
+++ b/src/main/java/br/edu/ifc/blumenau/analyzer/Main.java
@@ -1,5 +1,6 @@
 package br.edu.ifc.blumenau.analyzer;
 
+import io.github.cdimascio.dotenv.Dotenv;
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 
@@ -9,26 +10,36 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class Main {
 
-    static String openSourceProjectsDir= "/home/vitor-otto/opensource";
-    private static AtomicInteger totalAsserts = new AtomicInteger(0);
-    private static AtomicInteger assertsSemDesc = new AtomicInteger(0);
+    private static final AtomicInteger totalAsserts = new AtomicInteger(0);
+    private static final AtomicInteger totalAssertsSemDesc = new AtomicInteger(0);
+    private static final AtomicInteger totalAssertionRoulette = new AtomicInteger(0);
+    private static final ArrayList<String> metodosTesteChamados = new ArrayList<>();
 
     public static void main(String[] args) throws FileNotFoundException, NoSuchMethodException {
+        Dotenv dotenv = Dotenv.load();
+
+        String openSourceProjectsDir = dotenv.get("PROJECTS_DIR");
+
+        assert openSourceProjectsDir != null;
+
         Path projectDir = Paths.get(openSourceProjectsDir);
 
         try {
+
             Files.walk(projectDir)
                     .filter(Files::isRegularFile)
                     .filter(path -> path.toString().endsWith(".java"))
                     .forEach(Main::analyzeFile);
 
             System.out.println("Total asserts: " + totalAsserts);
-            System.out.println("Asserts sem descrição: " + assertsSemDesc);
-        } catch (Exception e) {
+            System.out.println("Asserts sem descrição: " + totalAssertsSemDesc);
+            System.out.println("Assertion Roulette: " + totalAssertionRoulette);
+        } catch (Exception ignored) {
 
         }
 
@@ -43,9 +54,9 @@ public class Main {
                 return;
             }
 
-            MethodVisitor methodVisitor = new MethodVisitor(totalAsserts, assertsSemDesc);
+            MethodVisitor methodVisitor = new MethodVisitor(totalAsserts, totalAssertsSemDesc, totalAssertionRoulette, metodosTesteChamados);
             compilationUnit.accept(methodVisitor, path);
-        } catch (IOException e) {
+        } catch (IOException ignored) {
 
         }
     }


### PR DESCRIPTION
- add an assertion roulette counter that is incremented if the parent method declaration has already been seen in an assertion method call. 
- read variables from a .env

OBS.: How to count assertion roulette should improve, but it's a way to check if a test Method has the assertion roulette smell.